### PR TITLE
[feature] Add Docker images for CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
 # rust-ci
 
 This repository contains helpful tools for the CI with CanalTP's Rust projects.
+
+## Docker images
+
+A few Docker images are available containing most of the useful tools to build
+and verify Rust projects.
+
+### `kisiodigital/rust-ci:latest`
+
+Based on Docker image `rust`, it provides the additional tools:
+
+- [`rustfmt`]: auto-formatting of the Rust source code
+- [`clippy`]: static linting of the Rust source code
+
+[`rustfmt`]: https://github.com/rust-lang/rustfmt
+[`clippy`]: https://github.com/rust-lang/rust-clippy
+
+### `kisiodigital/rust-ci:proj-latest`
+
+Based on Docker image `kisiodigital/rust-ci:latest`, it provides also the
+[Proj] library, allowing to compile a Rust project with [`proj`]'s crate.
+
+[proj]: https://github.com/OSGeo/PROJ
+[`proj`]: https://crates.io/crates/proj

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,0 +1,12 @@
+FROM rust:1.47-slim-buster
+
+RUN rustup component add rustfmt clippy
+# 'libssl-dev' and 'pkg-config' are useful for compilation of Rust crate
+# 'openssl-sys' which is used by 'cargo-audit'. Once compiled and installed,
+# only the library 'libssl1.1' is needed.
+RUN apt update \
+	&& apt install --yes libssl1.1 libssl-dev pkg-config \
+	&& cargo install cargo-audit \
+	&& apt purge --yes libssl-dev pkg-config \
+	&& apt autoremove --yes \
+	&& rm -rf /var/lib/apt/lists/*

--- a/proj/Dockerfile
+++ b/proj/Dockerfile
@@ -1,0 +1,19 @@
+FROM kisiodigital/rust-ci:latest
+
+ARG PROJ_VERSION="7.1.0"
+ENV PROJ_DEB "proj_${PROJ_VERSION}_amd64.deb"
+ENV GPG_KEY "C60D758F807A525534C5DFD57B639E3638A8112A"
+# For building Rust's crate 'proj-sys', the following Debian packages are needed:
+# - 'clang' provides 'llvm-config', 'libclang.so' and 'stddef.h' needed for compiling 'proj-sys'
+# - 'proj' provides 'proj.h' and 'libproj.so', needed for compiling 'proj-sys'
+# - 'libtiff5' provides 'libtiff.so', needed for linking when 'proj-sys' is used
+# - 'libcurl3-nss' provides 'libcurl-nss.so', needed for linking when 'proj-sys' is used
+RUN apt update \
+	&& apt install --yes apt-transport-https gnupg2 wget \
+	&& wget --quiet --output-document - "https://kisiodigital.jfrog.io/kisiodigital/api/gpg/key/public" | apt-key add - \
+	&& echo "deb [arch=amd64] https://kisiodigital.jfrog.io/kisiodigital/debian-local stretch main" > /etc/apt/sources.list.d/kisio-digital.list \
+	&& apt update \
+	&& apt install --yes clang proj=${PROJ_VERSION} libtiff5 libcurl3-nss \
+	&& apt purge --yes apt-transport-https gnupg2 wget \
+	&& apt autoremove --yes \
+	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I have one possible problem with this structure. Since `kisiodigital/rust-ci:proj-latest` depends on `kisiodigital/rust-ci:latest`, we might have a problem with the automatic scheduling of the jobs on Dockerhub to build the images. Any idea? Advice?

ref: ND-1103.