### PR TITLE
[feature] Bump to version 1.48 of Rust

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,5 +1,6 @@
 FROM rust:1.48-slim-buster
 
+ENV CARGO_TARGET_DIR=/tmp/cargo-target
 RUN rustup component add rustfmt clippy
 # 'libssl-dev' and 'pkg-config' are useful for compilation of Rust crate
 # 'openssl-sys' which is used by 'cargo-audit'. Once compiled and installed,

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.47-slim-buster
+FROM rust:1.48-slim-buster
 
 RUN rustup component add rustfmt clippy
 # 'libssl-dev' and 'pkg-config' are useful for compilation of Rust crate


### PR DESCRIPTION
Defines the `CARGO_TARGET_DIR` so we do not have to define it everywhere in other projects (see for example https://github.com/CanalTP/tartare-tools/commit/0e06aa5f105662340894ba33045d7c7b12ebfed4#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R9).