### PR TITLE
[feature] Add 'CARGO_HOME' to avoid the need of 'root' user

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -7,6 +7,7 @@ RUN apt update \
 	&& rm -rf /var/lib/apt/lists/*
 
 # For Rust
+ENV CARGO_HOME=/tmp/cargo
 ENV CARGO_TARGET_DIR=/tmp/cargo-target
 RUN rustup component add rustfmt clippy
 # 'libssl-dev' and 'pkg-config' are useful for compilation of Rust crate


### PR DESCRIPTION
By default, `cargo` downloads all crates to `/usr/local/cargo/registry/cache` which is not accessible for a non-`root` user. Changing `CARGO_HOME` to somewhere in `/tmp/` allow regular user to use `cargo`.

This change is needed for `CanalTP/tartare-tools#167`.